### PR TITLE
Better formatting in gmail for exception and backtrace

### DIFF
--- a/lib/chef/handler/mail.erb
+++ b/lib/chef/handler/mail.erb
@@ -11,6 +11,6 @@ Updated Resources:
 <% end -%>
 
 <% if @run_status.failed? -%>
-<%= @run_status.formatted_exception %>
-<%= Array(@run_status.backtrace).join("\n") %>
+  <%= @run_status.formatted_exception %>
+  <%= Array(@run_status.backtrace).join("\n") %>
 <% end -%>


### PR DESCRIPTION
The updated resources format great in gmail, this just makes the
backtrace and exception format the same way to make them more readable.
