### PR TITLE
Add SMTP support and use name vs. fqdn

### DIFF
--- a/lib/chef/handler/mail.erb
+++ b/lib/chef/handler/mail.erb
@@ -1,4 +1,4 @@
-Results of <%= @status %> Chef run on <%= @run_status.node.fqdn %>
+Results of <%= @status %> Chef run on <%= @run_status.node.name %>
 
 Start time: <%= @run_status.start_time %>
 End time: <%= @run_status.end_time %>

--- a/lib/chef/handler/mail.rb
+++ b/lib/chef/handler/mail.rb
@@ -17,7 +17,6 @@ require 'chef'
 require 'chef/handler'
 require 'erubis'
 require 'pony'
-require 'yaml'
 
 class MailHandler < Chef::Handler
   attr_reader :options
@@ -67,7 +66,8 @@ class MailHandler < Chef::Handler
         :port => options[:smtp_port],
         :user_name => options[:smtp_username],
         :password => options[:smtp_password],
-        :authentiction => :login,
+        :authentication => options[:smtp_authentication],
+        :domain => options[:smtp_domain],
         :enable_starttls_auto => true
       }
     )

--- a/lib/chef/handler/mail.rb
+++ b/lib/chef/handler/mail.rb
@@ -17,20 +17,29 @@ require 'chef'
 require 'chef/handler'
 require 'erubis'
 require 'pony'
+require 'yaml'
 
 class MailHandler < Chef::Handler
   attr_reader :options
   def initialize(opts = {})
     @options = {
       :to_address => "root",
-      :template_path => File.join(File.dirname(__FILE__), "mail.erb")
+      :template_path => File.join(File.dirname(__FILE__), "mail.erb"),
+      :from_address => "chef-client",
+      :smtp_host => "localhost",
+      :smtp_port => '25',
+      :smtp_username => "chef-client",
+      :smtp_password => "",
+      :smtp_authentication => :plain,
+      :smtp_domain => 'localhost.localdomain'
     }
     @options.merge! opts
+    puts @options.to_yaml
   end
 
   def report
     status = success? ? "Successful" : "Failed"
-    subject = "#{status} Chef run on node #{node.fqdn}"
+    subject = "#{status} Chef run on node #{node.name}"
 
     Chef::Log.debug("mail handler template path: #{options[:template_path]}")
     if File.exists? options[:template_path]
@@ -44,14 +53,23 @@ class MailHandler < Chef::Handler
       :status => status,
       :run_status => run_status
     }
-
+    
     body = Erubis::Eruby.new(template).evaluate(context)
 
     Pony.mail(
       :to => options[:to_address],
-      :from => "chef-client@#{node.fqdn}",
+      :from => options[:from_address],
       :subject => subject,
-      :body => body
+      :body => body,
+      :via => :smtp,
+      :via_options => {
+        :address => options[:smtp_host],
+        :port => options[:smtp_port],
+        :user_name => options[:smtp_username],
+        :password => options[:smtp_password],
+        :authentiction => :login,
+        :enable_starttls_auto => true
+      }
     )
   end
 end


### PR DESCRIPTION
I've patched this to work with remote SMTP servers as well as working on nodes that may not have a FQDN defined. Let me know if you see areas for improvement.
