### PR TITLE
Fix for the mail subject if Ohai failed to set FQDN

### DIFF
--- a/lib/chef/handler/mail.rb
+++ b/lib/chef/handler/mail.rb
@@ -30,7 +30,13 @@ class MailHandler < Chef::Handler
 
   def report
     status = success? ? "Successful" : "Failed"
-    subject = "#{status} Chef run on node #{node.fqdn}"
+
+    if node.attribute?(:fqdn)
+      subject = "#{status} Chef run on node #{node.fqdn}"
+    else
+      subject = "#{status} Chef run on node #{node.ipaddress} (Ohai has failed to set FQDN)"
+      Chef::Log.debug("Ohai has not set fqdn for this node, using ipaddress for the subject instead")
+    end
 
     Chef::Log.debug("mail handler template path: #{options[:template_path]}")
     if File.exists? options[:template_path]


### PR DESCRIPTION
Use node.ipaddress instead of node.fqdn if fqdn is not set.
Sometimes Ohai fails to set fqdn for the node. A couple of bugs are open for that.

Example below:

Running handlers:\x1b[0m
[2014-05-08T15:06:57-04:00] ERROR: Running exception handlers
[2014-05-08T15:06:57-04:00] ERROR: Report handler MailHandler raised #<NoMethodError: Undefined method or attribute `fqdn\' on `node\'>
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/node/attribute.rb:358:in `method_missing\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/node.rb:237:in`method_missing\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-handler-mail-0.1.2/lib/chef/handler/mail.rb:33:in `report\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/handler.rb:226:in`run_report_unsafe\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/handler.rb:214:in `run_report_safely\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/handler.rb:118:in`block in run_exception_handlers\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/handler.rb:117:in `each\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/handler.rb:117:in`run_exception_handlers\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/handler.rb:127:in `block in <class:Handler>\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/client.rb:133:in`call\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/client.rb:133:in `block in run_failed\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/client.rb:132:in`each\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/client.rb:132:in `run_failed\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/client.rb:447:in`rescue in do_run\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/client.rb:459:in `do_run\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/client.rb:213:in`block in run\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/client.rb:207:in `fork\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/client.rb:207:in`run\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/application.rb:217:in `run_chef_client\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/application/client.rb:328:in`block in run_application\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/application/client.rb:317:in `loop\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/application/client.rb:317:in`run_application\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/lib/chef/application.rb:67:in `run\'
[2014-05-08T15:06:57-04:00] ERROR: /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.12.4/bin/chef-client:26:in`<top (required)>\'
[2014-05-08T15:06:57-04:00] ERROR: /usr/bin/chef-client:23:in `load\'
