### PR TITLE
Don't continue to alert on failed hosts

### DIFF
--- a/lib/chef/handler/mail.rb
+++ b/lib/chef/handler/mail.rb
@@ -22,8 +22,8 @@ class MailHandler < Chef::Handler
   attr_reader :options
   def initialize(opts = {})
     @options = {
-      to_address: "root",
-      template_path: File.join(File.dirname(__FILE__), "mail.erb")
+      :to_address => "root",
+      :template_path => File.join(File.dirname(__FILE__), "mail.erb")
     }
     @options.merge! opts
   end
@@ -43,17 +43,17 @@ class MailHandler < Chef::Handler
     end
 
     context = {
-      status: status,
-      run_status: run_status
+      :status => status,
+      :run_status => run_status
     }
 
     body = Erubis::Eruby.new(template).evaluate(context)
 
     Pony.mail(
-      to: options[:to_address],
-      from: "chef-client@#{node.fqdn}",
-      subject: subject,
-      body: body
+      :to => options[:to_address],
+      :from => "chef-client@#{node.fqdn}",
+      :subject => subject,
+      :body => body
     )
   end
 

--- a/lib/chef/handler/mail/version.rb
+++ b/lib/chef/handler/mail/version.rb
@@ -1,3 +1,3 @@
 class MailHandler
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/lib/chef/handler/mail/version.rb
+++ b/lib/chef/handler/mail/version.rb
@@ -1,3 +1,3 @@
 class MailHandler
-  VERSION = "0.1.3"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Save the failed state in the Chef cache so it doesn't continue to spam on failed nodes
