### PR TITLE
Don't crash template generation after compile-time error

### DIFF
--- a/lib/chef/handler/mail.erb
+++ b/lib/chef/handler/mail.erb
@@ -4,10 +4,12 @@ Start time: <%= @run_status.start_time %>
 End time: <%= @run_status.end_time %>
 Elapsed time: <%= @run_status.elapsed_time %>
 
+<% if @run_status.updated_resources -%>
 Updated Resources:
 
-<% @run_status.updated_resources.each do |r| -%>
-   <%= r.to_s %>
+   <% @run_status.updated_resources.each do |r| -%>
+      <%= r.to_s %>
+   <% end -%>
 <% end -%>
 
 <% if @run_status.failed? -%>


### PR DESCRIPTION
Currently after a compile-time error caused by eg. a raise or exit, will cause the chef-handler-mail template generation to crash with: 

```
Report handler MailHandler raised #<NoMethodError: undefined method `each' for nil:NilClass>
```
