### PR TITLE
Ensure any passed options are converted to symbols

### DIFF
--- a/lib/chef/handler/mail.rb
+++ b/lib/chef/handler/mail.rb
@@ -25,7 +25,7 @@ class MailHandler < Chef::Handler
       :to_address => "root",
       :template_path => File.join(File.dirname(__FILE__), "mail.erb")
     }
-    @options.merge! opts
+    @options.merge! Hash[opts.map{ |k, v| [k.to_sym, v] }]
   end
 
   def report


### PR DESCRIPTION
Ran into some issues using this handler with the [chef-client](https://github.com/opscode-cookbooks/chef-client#start-report-exception-handlers) cookbook.  The attributes end up being passed as strings and this library expects any keys to be passed as symbols.
