### PR TITLE
Use preferred node['fqdn'] method for accessing attribute

### DIFF
--- a/lib/chef/handler/mail.erb
+++ b/lib/chef/handler/mail.erb
@@ -1,4 +1,4 @@
-Results of <%= @status %> Chef run on <%= @run_status.node.fqdn %>
+Results of <%= @status %> Chef run on <%= @run_status.node['fqdn'] %>
 
 Start time: <%= @run_status.start_time %>
 End time: <%= @run_status.end_time %>

--- a/lib/chef/handler/mail.rb
+++ b/lib/chef/handler/mail.rb
@@ -30,7 +30,7 @@ class MailHandler < Chef::Handler
 
   def report
     status = success? ? "Successful" : "Failed"
-    subject = "#{status} Chef run on node #{node.fqdn}"
+    subject = "#{status} Chef run on node #{node['fqdn']}"
 
     Chef::Log.debug("mail handler template path: #{options[:template_path]}")
     if File.exists? options[:template_path]
@@ -49,7 +49,7 @@ class MailHandler < Chef::Handler
 
     Pony.mail(
       :to => options[:to_address],
-      :from => "chef-client@#{node.fqdn}",
+      :from => "chef-client@#{node['fqdn']}",
       :subject => subject,
       :body => body
     )


### PR DESCRIPTION
This resolves #16

Using `node.fqdn` was removed in newer versions of Chef and breaks this handler.

Signed-off-by: Lance Albertson <lance@osuosl.org>
